### PR TITLE
Centralize WebRadio buffer queue

### DIFF
--- a/addons/webradio/node_types/httpclientinstance.gd
+++ b/addons/webradio/node_types/httpclientinstance.gd
@@ -8,6 +8,9 @@ signal buffer_ready(buffer: AudioStreamMP3)
 
 var http_client: HTTPClient
 
+var _queue: Array[AudioStreamMP3] = []
+var _current_stream: AudioStreamMP3 = null
+
 const buffer_size: int = 320 * 1000
 const buffer_emit_threshold: int = 320 * 1000 / 8
 
@@ -81,8 +84,20 @@ func _parse_url(url: String) -> Dictionary:
 	return result
 
 func _emit_buffer() -> void:
-	var audio_stream = AudioStreamMP3.new()
-	audio_stream.data = buffer
-	buffer.clear()
-	emit_signal("buffer_ready", audio_stream)
-	printt("Emitted buffer")
+        var audio_stream = AudioStreamMP3.new()
+        audio_stream.data = buffer
+        buffer.clear()
+        _queue.append(audio_stream)
+        if _current_stream == null:
+                _play_next()
+
+func _play_next() -> void:
+        if _queue.is_empty():
+                return
+        _current_stream = _queue.pop_front()
+        emit_signal("buffer_ready", _current_stream)
+        printt("Emitted buffer")
+
+func player_done() -> void:
+        _current_stream = null
+        _play_next()

--- a/addons/webradio/node_types/webradiostreamplayer.gd
+++ b/addons/webradio/node_types/webradiostreamplayer.gd
@@ -3,14 +3,18 @@ class_name WebRadioStreamPlayer
 
 @export var url: String
 
+var _http_instance: HTTPClientInstance
+
 func _ready() -> void:
-	var http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if http_instance == null:
-		http_instance = WebRadioStreamHelper.add_radio(url)
-	
-	http_instance.buffer_ready.connect(_refresh_stream)
+        self.process_thread_group = Node.PROCESS_THREAD_GROUP_SUB_THREAD
+        _http_instance = WebRadioStreamHelper.get_radio(url)
+
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        finished.connect(_http_instance.player_done)
+        _http_instance.buffer_ready.connect(_refresh_stream)
 
 func _refresh_stream(new_stream: AudioStreamMP3):
-	self.set_deferred("stream", new_stream)
-	self.call_deferred("play", 0)
+        self.set_deferred("stream", new_stream)
+        self.call_deferred("play", 0)

--- a/addons/webradio/node_types/webradiostreamplayer2d.gd
+++ b/addons/webradio/node_types/webradiostreamplayer2d.gd
@@ -3,18 +3,18 @@ class_name WebRadioStreamPlayer2D
 
 @export var url: String
 
+var _http_instance: HTTPClientInstance
+
 func _ready() -> void:
-	self.process_thread_group = Node.PROCESS_THREAD_GROUP_SUB_THREAD
-	
-	var http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if http_instance == null:
-		http_instance = WebRadioStreamHelper.add_radio(url)
-	
-	if http_instance.player_done_connected == false:
-		self.finished.connect(http_instance.player_done)
-		http_instance.player_done_connected = true
-	http_instance.buffer_ready.connect(_refresh_stream)
+        self.process_thread_group = Node.PROCESS_THREAD_GROUP_SUB_THREAD
+
+        _http_instance = WebRadioStreamHelper.get_radio(url)
+
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        self.finished.connect(_http_instance.player_done)
+        _http_instance.buffer_ready.connect(_refresh_stream)
 
 func _refresh_stream(new_stream: AudioStreamMP3):
 	self.set_deferred("stream", new_stream)

--- a/addons/webradio/node_types/webradiostreamplayer3d.gd
+++ b/addons/webradio/node_types/webradiostreamplayer3d.gd
@@ -3,16 +3,17 @@ class_name WebRadioStreamPlayer3D
 
 @export var url: String
 
+var _http_instance: HTTPClientInstance
+
 func _ready() -> void:
-	var http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if http_instance == null:
-		http_instance = WebRadioStreamHelper.add_radio(url)
-	
-	if http_instance.player_done_connected == false:
-		self.finished.connect(http_instance.player_done)
-		http_instance.player_done_connected = true
-	http_instance.buffer_ready.connect(_refresh_stream)
+        self.process_thread_group = Node.PROCESS_THREAD_GROUP_SUB_THREAD
+        _http_instance = WebRadioStreamHelper.get_radio(url)
+
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        self.finished.connect(_http_instance.player_done)
+        _http_instance.buffer_ready.connect(_refresh_stream)
 
 func _refresh_stream(new_stream: AudioStreamMP3):
 	self.set_deferred("stream", new_stream)


### PR DESCRIPTION
## Summary
- manage MP3 segment queue inside `HTTPClientInstance` so all radio players share buffered audio
- hook WebRadioStreamPlayer, 2D, and 3D variants to the shared queue and sub-thread processing for smoother playback

## Testing
- `godot4 --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68baaecdb9ac832783474ae74eaff594