### PR TITLE
Use AudioStreamGenerator with MP3 decoding

### DIFF
--- a/addons/webradio/node_types/httpclientinstance.gd
+++ b/addons/webradio/node_types/httpclientinstance.gd
@@ -1,15 +1,13 @@
 extends Node
 class_name HTTPClientInstance
 
-signal buffer_ready(buffer: AudioStreamMP3)
+signal buffer_ready(pcm: PackedByteArray)
 
 @export var radio_url: String
 @export var buffer: PackedByteArray
 
 var http_client: HTTPClient
-
-var _queue: Array[AudioStreamMP3] = []
-var _current_stream: AudioStreamMP3 = null
+var decoder: Mp3Decoder = Mp3Decoder.new()
 
 const buffer_time: float = 5
 const buffer_size: int = 320 * 1000 / 8 * buffer_time * 2
@@ -85,20 +83,7 @@ func _parse_url(url: String) -> Dictionary:
 	return result
 
 func _emit_buffer() -> void:
-		var audio_stream = AudioStreamMP3.new()
-		audio_stream.data = buffer
-		buffer.clear()
-		_queue.append(audio_stream)
-		if _current_stream == null:
-				_play_next()
-
-func _play_next() -> void:
-		if _queue.is_empty():
-				return
-		_current_stream = _queue.pop_front()
-		emit_signal("buffer_ready", _current_stream)
-		printt("Emitted buffer")
-
-func player_done() -> void:
-		_current_stream = null
-		call_deferred("_play_next")
+        var pcm = decoder.decode(buffer)
+        buffer.clear()
+        emit_signal("buffer_ready", pcm)
+        printt("Emitted buffer")

--- a/addons/webradio/node_types/webradiostreamplayer.gd
+++ b/addons/webradio/node_types/webradiostreamplayer.gd
@@ -4,16 +4,31 @@ class_name WebRadioStreamPlayer
 @export var url: String
 
 var _http_instance: HTTPClientInstance
+var _playback: AudioStreamGeneratorPlayback
 
 func _ready() -> void:
-	_http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if _http_instance == null:
-		_http_instance = WebRadioStreamHelper.add_radio(url)
-		
-	finished.connect(_http_instance.player_done)
-	_http_instance.buffer_ready.connect(_refresh_stream)
+        _http_instance = WebRadioStreamHelper.get_radio(url)
 
-func _refresh_stream(new_stream: AudioStreamMP3):
-	self.set_deferred("stream", new_stream)
-	self.call_deferred("play", 0)
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        var generator := AudioStreamGenerator.new()
+        generator.mix_rate = 48000
+        generator.buffer_length = 5.0
+        stream = generator
+        play()
+        _playback = get_stream_playback()
+
+        _http_instance.buffer_ready.connect(_refresh_stream)
+
+func _refresh_stream(pcm: PackedByteArray) -> void:
+        if _playback == null:
+                return
+        var i := 0
+        while i < pcm.size():
+                while _playback.get_frames_available() <= 0:
+                        await get_tree().process_frame
+                var left = pcm.decode_s16(i) / 32768.0
+                var right = pcm.decode_s16(i + 2) / 32768.0
+                _playback.push_frame(Vector2(left, right))
+                i += 4

--- a/addons/webradio/node_types/webradiostreamplayer2d.gd
+++ b/addons/webradio/node_types/webradiostreamplayer2d.gd
@@ -4,16 +4,31 @@ class_name WebRadioStreamPlayer2D
 @export var url: String
 
 var _http_instance: HTTPClientInstance
+var _playback: AudioStreamGeneratorPlayback
 
 func _ready() -> void:
-	_http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if _http_instance == null:
-		_http_instance = WebRadioStreamHelper.add_radio(url)
-	
-	self.finished.connect(_http_instance.player_done)
-	_http_instance.buffer_ready.connect(_refresh_stream)
+        _http_instance = WebRadioStreamHelper.get_radio(url)
 
-func _refresh_stream(new_stream: AudioStreamMP3):
-	self.set_deferred("stream", new_stream)
-	self.call_deferred("play", 0)
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        var generator := AudioStreamGenerator.new()
+        generator.mix_rate = 48000
+        generator.buffer_length = 5.0
+        stream = generator
+        play()
+        _playback = get_stream_playback()
+
+        _http_instance.buffer_ready.connect(_refresh_stream)
+
+func _refresh_stream(pcm: PackedByteArray) -> void:
+        if _playback == null:
+                return
+        var i := 0
+        while i < pcm.size():
+                while _playback.get_frames_available() <= 0:
+                        await get_tree().process_frame
+                var left = pcm.decode_s16(i) / 32768.0
+                var right = pcm.decode_s16(i + 2) / 32768.0
+                _playback.push_frame(Vector2(left, right))
+                i += 4

--- a/addons/webradio/node_types/webradiostreamplayer3d.gd
+++ b/addons/webradio/node_types/webradiostreamplayer3d.gd
@@ -4,16 +4,31 @@ class_name WebRadioStreamPlayer3D
 @export var url: String
 
 var _http_instance: HTTPClientInstance
+var _playback: AudioStreamGeneratorPlayback
 
 func _ready() -> void:
-	_http_instance = WebRadioStreamHelper.get_radio(url)
-	
-	if _http_instance == null:
-		_http_instance = WebRadioStreamHelper.add_radio(url)
-	
-	self.finished.connect(_http_instance.player_done)
-	_http_instance.buffer_ready.connect(_refresh_stream)
+        _http_instance = WebRadioStreamHelper.get_radio(url)
 
-func _refresh_stream(new_stream: AudioStreamMP3):
-	self.set_deferred("stream", new_stream)
-	self.call_deferred("play", 0)
+        if _http_instance == null:
+                _http_instance = WebRadioStreamHelper.add_radio(url)
+
+        var generator := AudioStreamGenerator.new()
+        generator.mix_rate = 48000
+        generator.buffer_length = 5.0
+        stream = generator
+        play()
+        _playback = get_stream_playback()
+
+        _http_instance.buffer_ready.connect(_refresh_stream)
+
+func _refresh_stream(pcm: PackedByteArray) -> void:
+        if _playback == null:
+                return
+        var i := 0
+        while i < pcm.size():
+                while _playback.get_frames_available() <= 0:
+                        await get_tree().process_frame
+                var left = pcm.decode_s16(i) / 32768.0
+                var right = pcm.decode_s16(i + 2) / 32768.0
+                _playback.push_frame(Vector2(left, right))
+                i += 4


### PR DESCRIPTION
## Summary
- Stream HTTP radio data through `AudioStreamGenerator` instead of queuing `AudioStreamMP3`
- Decode MP3 chunks using `Mp3Decoder` and push PCM frames to playback
- Update 2D/3D stream players to feed decoded frames into generator playback

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `gdformat --check addons/webradio/node_types/*.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bac00535fc83278dafff284de2556f