### PR TITLE
Integrate FFMpegCore MP3 decoder via C#

### DIFF
--- a/addons/webradio/node_types/Mp3Decoder.cs
+++ b/addons/webradio/node_types/Mp3Decoder.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using Godot;
+using FFMpegCore;
+using FFMpegCore.Pipes;
+
+[GlobalClass]
+public partial class Mp3Decoder : RefCounted
+{
+    public byte[] Decode(byte[] buffer)
+    {
+        using var inputStream = new MemoryStream(buffer);
+        using var outputStream = new MemoryStream();
+
+        FFMpegArguments
+            .FromPipeInput(new StreamPipeSource(inputStream))
+            .OutputToPipe(new StreamPipeSink(outputStream), options => options
+                .WithAudioCodec("pcm_s16le")
+                .WithCustomArgument("-ac 2")
+                .WithAudioSamplingRate(48000)
+                .ForceFormat("s16le"))
+            .ProcessSynchronously();
+
+        return outputStream.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary
- add C# `Mp3Decoder` leveraging FFMpegCore to turn MP3 data into raw PCM

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bad3a782c4832795984e1f4a4fbb4b