### PR TITLE
Use Mp3Decoder in stream players

### DIFF
--- a/addons/webradio/node_types/webradiostreamplayer.gd
+++ b/addons/webradio/node_types/webradiostreamplayer.gd
@@ -8,16 +8,17 @@ var _playback: AudioStreamGeneratorPlayback
 var _frame_queue: Array
 var _queue_mutex: Mutex
 var _push_thread: Thread
-var _thread_running := false
+var _thread_running: bool = false
+var _decoder: Mp3Decoder = Mp3Decoder.new()
 
-const REFILL_THRESHOLD := 1024
+const REFILL_THRESHOLD: int = 1024
 
 func _ready() -> void:
 	_http_instance = WebRadioStreamHelper.get_radio(url)
 	if _http_instance == null:
 		_http_instance = WebRadioStreamHelper.add_radio(url)
 
-	var generator := AudioStreamGenerator.new()
+       var generator: AudioStreamGenerator = AudioStreamGenerator.new()
 	generator.mix_rate = 48000
 	generator.buffer_length = 5.0
 	stream = generator
@@ -25,7 +26,7 @@ func _ready() -> void:
 	_playback = get_stream_playback()
 
 	# Preload ~0.5s of silence
-	var initial_frames := int(generator.mix_rate * 0.5)
+       var initial_frames: int = int(generator.mix_rate * 0.5)
 	for i in range(initial_frames):
 		_playback.push_frame(Vector2.ZERO)
 
@@ -38,7 +39,7 @@ func _process(_delta: float) -> void:
 	if _playback == null:
 		return
 
-	var avail := _playback.get_frames_available()
+       var avail: int = _playback.get_frames_available()
 	if avail <= 0:
 		return
 
@@ -55,20 +56,23 @@ func _process(_delta: float) -> void:
 		avail -= 1
 
 
-func _refresh_stream(pcm: PackedByteArray) -> void:
-	if _playback == null or pcm.is_empty():
-		return
-	var local_queue: Array[Vector2] = []
-	var i := 0
-	# s16le stereo → 4 bytes per frame
-	while i + 3 < pcm.size():
-		var l := pcm.decode_s16(i) / 32768.0
-		var r := pcm.decode_s16(i + 2) / 32768.0
-		local_queue.append(Vector2(l, r))
-		i += 4
-	_queue_mutex.lock()
-	_frame_queue += local_queue
-	_queue_mutex.unlock()
+func _refresh_stream(mp3: PackedByteArray) -> void:
+        if _playback == null or mp3.is_empty():
+                return
+       var pcm: PackedByteArray = _decoder.decode(mp3)
+        if pcm.is_empty():
+                return
+        var local_queue: Array[Vector2] = []
+       var i: int = 0
+        # s16le stereo → 4 bytes per frame
+        while i + 3 < pcm.size():
+               var l: float = pcm.decode_s16(i) / 32768.0
+               var r: float = pcm.decode_s16(i + 2) / 32768.0
+                local_queue.append(Vector2(l, r))
+                i += 4
+        _queue_mutex.lock()
+        _frame_queue += local_queue
+        _queue_mutex.unlock()
 
 
 func _push_frames(userdata) -> void:


### PR DESCRIPTION
## Summary
- forward raw MP3 data from HTTPClientInstance for external decoding
- decode MP3 chunks within all WebRadioStreamPlayer variants using Mp3Decoder
- replace inferred `:=` declarations with explicit typed assignments for editor compatibility

## Testing
- `dotnet build`
- `godot --headless --version` *(fails: command not found)*
- `godot3 --headless --version`


------
https://chatgpt.com/codex/tasks/task_e_68bad82637f48327b04cb6ef1bf90548