### PR TITLE
Warn when .NET support is missing

### DIFF
--- a/addons/webradio/plugin.gd
+++ b/addons/webradio/plugin.gd
@@ -2,9 +2,17 @@
 extends EditorPlugin
 
 func _enter_tree() -> void:
-	add_custom_type("WebRadioStreamPlayer", "AudioStreamPlayer", preload("res://addons/webradio/node_types/WebRadioStreamPlayer.cs"), preload("res://addons/webradio/icons/WebRadioStreamPlayer.svg"))
-	add_custom_type("WebRadioStreamPlayer2D", "AudioStreamPlayer2D", preload("res://addons/webradio/node_types/WebRadioStreamPlayer2D.cs"), preload("res://addons/webradio/icons/WebRadioStreamPlayer2D.svg"))
-	add_custom_type("WebRadioStreamPlayer3D", "AudioStreamPlayer3D", preload("res://addons/webradio/node_types/WebRadioStreamPlayer3D.cs"), preload("res://addons/webradio/icons/WebRadioStreamPlayer3D.svg"))
+	if not ClassDB.class_exists("CSharpScript"):
+		var dialog = AcceptDialog.new()
+		dialog.title = "Missing .NET support"
+		dialog.dialog_text = "WebRadio relies on Godot's .NET (C#) support. Please enable the .NET version of Godot to use this plugin."
+		get_editor_interface().get_base_control().add_child(dialog)
+		dialog.popup_centered()
+		return
+
+	add_custom_type("WebRadioStreamPlayer", "AudioStreamPlayer", load("res://addons/webradio/node_types/WebRadioStreamPlayer.cs"), load("res://addons/webradio/icons/WebRadioStreamPlayer.svg"))
+	add_custom_type("WebRadioStreamPlayer2D", "AudioStreamPlayer2D", load("res://addons/webradio/node_types/WebRadioStreamPlayer2D.cs"), load("res://addons/webradio/icons/WebRadioStreamPlayer2D.svg"))
+	add_custom_type("WebRadioStreamPlayer3D", "AudioStreamPlayer3D", load("res://addons/webradio/node_types/WebRadioStreamPlayer3D.cs"), load("res://addons/webradio/icons/WebRadioStreamPlayer3D.svg"))
 	add_autoload_singleton("WebRadioStreamHelper", "res://addons/webradio/node_types/WebRadioStreamHelper.cs")
 
 func _exit_tree() -> void:


### PR DESCRIPTION
## Summary
- warn users if Godot is run without .NET support
- load C# scripts at runtime to avoid parse errors when .NET is missing

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bb196ed2048327bd7ef1aed4c8a050